### PR TITLE
Include silent-error package

### DIFF
--- a/lib/ssh-adapter.js
+++ b/lib/ssh-adapter.js
@@ -2,7 +2,7 @@
 'use strict';
 var CoreObject = require('core-object');
 var Promise = require('ember-cli/lib/ext/promise');
-var SilentError = require('ember-cli/lib/errors/silent');
+var SilentError = require('silent-error');
 var ssh2 = require('ssh2');
 
 module.exports = CoreObject.extend({

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   ],
   "dependencies": {
     "core-object": "^1.1.0",
-    "ssh2": "^0.4.4"
+    "ssh2": "^0.4.4",
+    "silent-error": "^1.0.0"
   }
 }


### PR DESCRIPTION
This was extracted into a separate package since 1.13

This prevents deprecation messages every time we run the ember command
