### PR TITLE
add ssh agent config option

### DIFF
--- a/lib/ssh-adapter.js
+++ b/lib/ssh-adapter.js
@@ -43,6 +43,8 @@ module.exports = CoreObject.extend({
   _getFileList: function() {
     var conn = this.client;
     var config = this.config;
+    var connectionOptions = this._getConnectionOptions.bind(this)();
+
     return new Promise(function (resolve, reject) {
       conn.on('ready', function () {
         conn.sftp(function(err, sftp) {
@@ -60,11 +62,7 @@ module.exports = CoreObject.extend({
         });
       }).on('error', function (error) {
         reject(error);
-      }).connect({
-        host: config.host,
-        username: config.username,
-        privateKey: require('fs').readFileSync(config.privateKeyFile),
-      });
+      }).connect(connectionOptions);
     });
   },
 
@@ -90,8 +88,10 @@ module.exports = CoreObject.extend({
     if (revisions.indexOf(targetRevision) > -1) {
       var conn = this.client;
       var config = this.config;
+      var connectionOptions = this._getConnectionOptions.bind(this)();
       var revisionFile = config.remoteDir + targetRevision + '.html';
       var indexFile = config.remoteDir + 'index.html';
+
       return new Promise(function (resolve, reject) {
         conn.on('ready', function () {
           conn.sftp(function(err, sftp) {
@@ -114,11 +114,7 @@ module.exports = CoreObject.extend({
           });
         }).on('error', function (error) {
           reject(error);
-        }).connect({
-          host: config.host,
-          username: config.username,
-          privateKey: require('fs').readFileSync(config.privateKeyFile),
-        });
+        }).connect(connectionOptions);
       });
     } else {
       return this._printErrorMessage("Revision doesn't exist");
@@ -128,6 +124,8 @@ module.exports = CoreObject.extend({
   _uploadIfMissing: function(value, key) {
     var conn = this.client;
     var config = this.config;
+    var connectionOptions = this._getConnectionOptions.bind(this)();
+
     return new Promise(function(resolve, reject) {
       this._list()
       .then(function(revisions) {
@@ -148,11 +146,7 @@ module.exports = CoreObject.extend({
             });
           }).on('error', function (error) {
             reject(error);
-          }).connect({
-            host: config.host,
-            username: config.username,
-            privateKey: require('fs').readFileSync(config.privateKeyFile),
-          });
+          }).connect(connectionOptions);
         } else {
           reject(new SilentError('Revision already uploaded.'));
         }
@@ -176,5 +170,20 @@ module.exports = CoreObject.extend({
   _printErrorMessage: function (message) {
     return Promise.reject(new SilentError(message));
   },
+
+  _getConnectionOptions: function() {
+    var config = this.config;
+    var options = { host: config.host, username: config.username };
+
+    if (!!config.privateKeyFile) {
+      options.privateKey = require('fs').readFileSync(config.privateKeyFile);
+    }
+
+    if (!!config.agent) {
+      options.agent = config.agent;
+    }
+
+    return options;
+  }
 
 });


### PR DESCRIPTION
this allows me to connect via ssh-agent, in case my keyfile is encrypted. It _does_ require one additional `ssh-add -K` (or `ssh-add /path/to/keyfile`) step before that, don't know if there's any option to make ssh2 show a prompt for it.

On my system it works with `agent: process.env.SSH_AUTH_SOCK`, don't know if that's available in general. If so, this should probably added to the documentation.

another possibility would be to add an option to specify the passphrase, but i don't like that much.

edit: fixed missing semicolon
